### PR TITLE
add `get-token-accounts` helper function

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@jup-ag/core": "4.0.0-beta.17",
     "@solana/spl-token": "0.1.8",
     "@solana/web3.js": "^1.75.0",
+    "axios": "^1.4.0",
     "commander": "^9.1.0",
     "dotenv": "^16.0.0",
     "isomorphic-fetch": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1646,6 +1646,15 @@ axios@^1.2.1:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
+axios@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
+  integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"


### PR DESCRIPTION
returns token fee accounts (+ token name and symbol) for an owner pubkey in CSV format

<img width="870" alt="Screenshot 2023-05-14 at 20 11 16" src="https://github.com/jup-ag/jupiter-cli/assets/101902546/3d134656-2286-4195-8cca-820472c02169">

or in a table

<img width="1068" alt="Screenshot 2023-05-14 at 20 11 29" src="https://github.com/jup-ag/jupiter-cli/assets/101902546/8b8280c4-95ed-4548-86a6-0caeac7ed242">

values are different here as the accounts are random pubkeys for demo purposes

### future ideas

- return JSON format
- include balances of each account
- extract the owner pubkey from the keyfile